### PR TITLE
Fix bugs in build and installation files.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+gov.ornl.tasqc.keytrans/static/
+keyTransferClient-build/

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ From the base directory where you checked out the repository:
 ```sh
 mkdir keyTransferClient-build
 cd keyTransferClient-build
-cmake ../keyTransferClient-build
+cmake ../keyTransferClient
 ```
 
 You may pick any build directory you want, actually. Just replace `../` with the directory.

--- a/gov.ornl.tasqc.keytrans/dependency-reduced-pom.xml
+++ b/gov.ornl.tasqc.keytrans/dependency-reduced-pom.xml
@@ -25,6 +25,33 @@
       <plugin>
         <artifactId>maven-shade-plugin</artifactId>
         <version>2.3</version>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+            <configuration>
+              <transformers>
+                <transformer />
+                <transformer />
+              </transformers>
+            </configuration>
+          </execution>
+        </executions>
+        <configuration>
+          <createDependencyReducedPom>true</createDependencyReducedPom>
+          <filters>
+            <filter>
+              <artifact>*:*</artifact>
+              <excludes>
+                <exclude>META-INF/*.SF</exclude>
+                <exclude>META-INF/*.DSA</exclude>
+                <exclude>META-INF/*.RSA</exclude>
+              </excludes>
+            </filter>
+          </filters>
+        </configuration>
       </plugin>
       <plugin>
         <artifactId>maven-jar-plugin</artifactId>
@@ -41,6 +68,7 @@
       </plugin>
       <plugin>
         <artifactId>maven-site-plugin</artifactId>
+        <version>3.7.1</version>
         <configuration>
           <inputEncoding>UTF-8</inputEncoding>
           <outputEncoding>UTF-8</outputEncoding>

--- a/gov.ornl.tasqc.keytrans/pom.xml
+++ b/gov.ornl.tasqc.keytrans/pom.xml
@@ -35,6 +35,21 @@
 			<version>4.11</version>
 			<scope>test</scope>
 		</dependency>
+        <dependency>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+            <version>2.3.0</version>
+        </dependency>
+        <dependency>
+            <groupId>com.sun.xml.bind</groupId>
+            <artifactId>jaxb-core</artifactId>
+            <version>2.3.0</version>
+        </dependency>
+        <dependency>
+            <groupId>com.sun.xml.bind</groupId>
+            <artifactId>jaxb-impl</artifactId>
+            <version>2.3.0</version>
+        </dependency>
 	</dependencies>
 
 	<build>
@@ -107,6 +122,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-site-plugin</artifactId>
+                <version>3.7.1</version>
 				<configuration>
 					<inputEncoding>UTF-8</inputEncoding>
 					<outputEncoding>UTF-8</outputEncoding>

--- a/keyTransferClient/libcurlUtil/CMakeLists.txt
+++ b/keyTransferClient/libcurlUtil/CMakeLists.txt
@@ -40,7 +40,7 @@ SET(LIBRARY_NAME "curlUtil")
 
 #Collect all header filenames in this project 
 #and glob them in HEADERS
-file(GLOB HEADERS *.h)
+file(GLOB HEADERS *.h *.hpp)
 
 #Grab all of the source files
 file(GLOB SRC *.cpp)


### PR DESCRIPTION
## Closes #3
[Changed to newer version of maven plugin.](https://www.mkyong.com/maven/mvn-site-java-lang-classnotfoundexception-org-apache-maven-doxia-siterenderer-documentcontent/)
## Closes #4
Adds in class dependencies to overcome JAXB being removed from Java 11.
[Java 11 package javax.xml.bind does not exist](https://stackoverflow.com/questions/52502189/java-11-package-javax-xml-bind-does-not-exist)
## Closes #5
Updates cmake files to include *.hpp files (this ensures that HTTPInterface.hpp will be installed)
## Other changes:
- Updated the README to correct a typo in the installation instructions
- Updated .gitignore to include build files.